### PR TITLE
Cache fix

### DIFF
--- a/core/Base/Identifier.class.php
+++ b/core/Base/Identifier.class.php
@@ -40,7 +40,13 @@
 		
 		public function getId()
 		{
-			return $this->id;
+			if (
+				$this->id instanceof Identifier
+				&& $this->id->isFinalized()
+			)
+				return $this->id->getId();
+			else
+				return $this->id;
 		}
 		
 		/**

--- a/main/DAOs/GenericDAO.class.php
+++ b/main/DAOs/GenericDAO.class.php
@@ -355,13 +355,7 @@
 
 		public function dropObjectIdentityMapById($id)
 		{
-			if ($id instanceof Identifiable) {
-				$id = $id->getId();
-			}
-
-			if (isset($this->identityMap[$id])) {
-				unset($this->identityMap[$id]);
-			}
+			unset($this->identityMap[$id]);
 
 			return $this;
 		}
@@ -440,26 +434,13 @@
 		
 		private function addObjectToMap(Identifiable $object)
 		{
-			$id = $object->getId();
-
-			if ($id instanceof Identifier) {
-				$id = $id->getId();
-			}
-
-			return $this->identityMap[$id] = $object;
+			return $this->identityMap[$object->getId()] = $object;
 		}
 
 		private function addObjectListToMap($list)
 		{
-			foreach ($list as $object) {
-				$id = $object->getId();
-
-				if ($id instanceof Identifier) {
-					$id = $id->getId();
-				}
-
-				$this->identityMap[$id] = $object;
-			}
+			foreach ($list as $object)
+				$this->identityMap[$object->getId()] = $object;
 			
 			return $list;
 		}

--- a/main/DAOs/GenericDAO.class.php
+++ b/main/DAOs/GenericDAO.class.php
@@ -355,7 +355,13 @@
 
 		public function dropObjectIdentityMapById($id)
 		{
-			unset($this->identityMap[$id]);
+			if ($id instanceof Identifiable) {
+				$id = $id->getId();
+			}
+
+			if (isset($this->identityMap[$id])) {
+				unset($this->identityMap[$id]);
+			}
 
 			return $this;
 		}
@@ -434,13 +440,26 @@
 		
 		private function addObjectToMap(Identifiable $object)
 		{
-			return $this->identityMap[$object->getId()] = $object;
+			$id = $object->getId();
+
+			if ($id instanceof Identifier) {
+				$id = $id->getId();
+			}
+
+			return $this->identityMap[$id] = $object;
 		}
-		
+
 		private function addObjectListToMap($list)
 		{
-			foreach ($list as $object)
-				$this->identityMap[$object->getId()] = $object;
+			foreach ($list as $object) {
+				$id = $object->getId();
+
+				if ($id instanceof Identifier) {
+					$id = $id->getId();
+				}
+
+				$this->identityMap[$id] = $object;
+			}
 			
 			return $list;
 		}

--- a/main/DAOs/StorableDAO.class.php
+++ b/main/DAOs/StorableDAO.class.php
@@ -26,14 +26,19 @@
 		
 		public function add(Identifiable $object)
 		{
+			$sequence =
+				DBPool::getByDao($this)->obtainSequence(
+					$this->getSequence()
+				);
+
+			if ($sequence instanceof Identifier) {
+				$id = $sequence->getId();
+			}
+
 			return
 				$this->inject(
 					OSQL::insert(),
-					$object->setId(
-						DBPool::getByDao($this)->obtainSequence(
-							$this->getSequence()
-						)
-					)
+					$object->setId($id)
 				);
 		}
 		

--- a/main/DAOs/StorableDAO.class.php
+++ b/main/DAOs/StorableDAO.class.php
@@ -26,19 +26,14 @@
 		
 		public function add(Identifiable $object)
 		{
-			$sequence =
-				DBPool::getByDao($this)->obtainSequence(
-					$this->getSequence()
-				);
-
-			if ($sequence instanceof Identifier) {
-				$id = $sequence->getId();
-			}
-
 			return
 				$this->inject(
 					OSQL::insert(),
-					$object->setId($id)
+					$object->setId(
+						DBPool::getByDao($this)->obtainSequence(
+							$this->getSequence()
+						)
+					)
 				);
 		}
 		


### PR DESCRIPTION
Я бы никогда не нашел это, если бы не мой днс демон. Ошибка появляется часто, но после сохранения данных в базе. Данные вроде целы, поэтому всем пофиг, но если после сохранения данных заложена логика, то будет падать на эксепшн, спасает только ловля исключений.

В onPHP все объекты, которые вносятся в базу, кешируются до попадания туда. Id в кеше, для каждой записи, на момент кеширования, есть только в случае использования PgSQL, если это MySQLim, то в кеш из-за этого бага попадает не id, а пустой обьект Identifier. 

Ошибки по системе в самых разных местах, вот такого типа:

Illegal offset type
Illegal offset type in isset or empty

Потому что в GenericDAO вместо ключа используется обьект:
```
return $this->identityMap[$object->getId()] = $object; // $object->getId() это Identifier, ошибка
```
и
```
unset($this->identityMap[$id]); // $id это Identifier, ошибка
```

Вот такие пироги.